### PR TITLE
Fix issues while copying docs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,15 @@
   system ? builtins.currentSystem }:
 
 let inherit (pkgs) lib;
-    releases = builtins.fromJSON (lib.strings.fileContents ./sources.json);
+  releases = builtins.fromJSON (lib.strings.fileContents ./sources.json);
+  installPhase = ''
+    mkdir -p $out/{doc,bin,lib}
+    [ -d docs ] && cp -r docs/* $out/doc
+    [ -d doc ] && cp -r doc/* $out/doc
+    cp -r lib/* $out/lib
+    cp zig $out/bin/zig
+  '';
+
 in lib.attrsets.mapAttrs (k: v: 
   if k == "master" then
     lib.attrsets.mapAttrs (k: v:
@@ -15,12 +23,7 @@ in lib.attrsets.mapAttrs (k: v:
         dontConfigure = true;
         dontBuild = true;
         dontFixup = true;
-        installPhase = ''
-          mkdir -p $out/{doc,bin,lib}
-          cp -r docs/* $out/doc
-          cp -r lib/* $out/lib
-          cp zig $out/bin/zig
-        '';
+        installPhase = installPhase;
       }))
       v
   else
@@ -33,14 +36,6 @@ in lib.attrsets.mapAttrs (k: v:
       dontConfigure = true;
       dontBuild = true;
       dontFixup = true;
-      installPhase = ''
-        mkdir -p $out/{doc,bin,lib}
-        cp -r ${if k == "0.6.0" then "doc/*"
-                else
-                  if k == "0.7.0" then "langref.html"
-                  else "docs/*"} $out/doc
-        cp -r lib/* $out/lib
-        cp zig $out/bin/zig
-      '';
+      installPhase = installPhase;
     })
   releases


### PR DESCRIPTION
On my host (Darwin/Big Sur) builds fail due to `cp` not able to find directory to copy.

It seems that different versions of nix have a slightly different name for docs:

- 0.6.x version uses `doc`
- 0.7.x version uses `docs`
- 0.8.x version uses `doc`
- 0.9.x version uses `docs`

Downloaded from https://ziglang.org/download/

```
├── zig-linux-aarch64-0.8.0
│   ├── LICENSE
│   ├── doc
│   ├── lib
│   └── zig
├── zig-linux-x86_64-0.6.0
│   ├── LICENSE
│   ├── doc
│   └── lib
├── zig-linux-x86_64-0.7.1
│   ├── LICENSE
│   ├── docs
│   ├── lib
│   └── zig
└── zig-macos-aarch64-0.9.0-dev.897+81e2034d4
    ├── LICENSE
    ├── docs
    ├── lib
    └── zig
```