### PR TITLE
Add aarch64-darwin to supported archs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1610051610,
-        "narHash": "sha256-U9rPz/usA1/Aohhk7Cmc2gBrEEKRzcW4nwPWMPwja4Y=",
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3982c9903e93927c2164caa727cd3f6a0e6d14cc",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1613343273,
-        "narHash": "sha256-YlSATlS8L16u1ooX/cCN7/vFcsI1TTOQegIc9dt/mco=",
+        "lastModified": 1631288242,
+        "narHash": "sha256-sXm4KiKs7qSIf5oTAmrlsEvBW193sFj+tKYVirBaXz0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "be864bbd6763cd4c92777643b9c4c6f07c3390d5",
+        "rev": "0e24c87754430cb6ad2f8c8c8021b29834a8845e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   };
   outputs = { self, nixpkgs, flake-utils, ... }:
     # List of systems where binaries are provided.
-    let systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" ];
+    let systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
     in flake-utils.lib.eachSystem systems (system:
       let pkgs = nixpkgs.legacyPackages.${system};
       in rec {

--- a/sources.json
+++ b/sources.json
@@ -36,19 +36,24 @@
     },
     "latest": {
       "x86_64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.952+0c091feb5.tar.xz",
-        "version": "0.9.0-dev.952+0c091feb5",
-        "sha256": "a7f08282a9dd8e5a3b48f3b3a303fe2e7044c54eaba023ed53a382e4c3529488"
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.1049+5d14590ed.tar.xz",
+        "version": "0.9.0-dev.1049+5d14590ed",
+        "sha256": "9eec473fa27602317fea549408a7af5f988dae614ff1d5864603d3d7b469146f"
       },
       "aarch64-linux": {
-        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.9.0-dev.952+0c091feb5.tar.xz",
-        "version": "0.9.0-dev.952+0c091feb5",
-        "sha256": "298f60820c11aa65c25239f3ae69197a2e4d5fd5aa731792e3d2c0d4766ec018"
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.9.0-dev.1049+5d14590ed.tar.xz",
+        "version": "0.9.0-dev.1049+5d14590ed",
+        "sha256": "010b1aeaa245c94d8f9bb617edeceefe990172d3029090bc85cba7f24da80d3a"
       },
       "x86_64-darwin": {
-        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.9.0-dev.952+0c091feb5.tar.xz",
-        "version": "0.9.0-dev.952+0c091feb5",
-        "sha256": "efd532009c482767ba9b4f0cbd9bbab65a787ac59d908d78bcf8eba6f9fcf1dd"
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.9.0-dev.1049+5d14590ed.tar.xz",
+        "version": "0.9.0-dev.1049+5d14590ed",
+        "sha256": "48210c909b9d1f6403cc138386128342b326d38b319c918d2b749d36322cbef4"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.9.0-dev.1049+5d14590ed.tar.xz",
+        "version": "0.9.0-dev.1049+5d14590ed",
+        "sha256": "a544d8c7e09f08f09baf1a6836d6850d957cbdff72c868aba3961875bba8e947"
       }
     },
     "2021-02-20": {
@@ -2293,6 +2298,33 @@
         "url": "https://ziglang.org/builds/zig-macos-x86_64-0.9.0-dev.952+0c091feb5.tar.xz",
         "version": "0.9.0-dev.952+0c091feb5",
         "sha256": "efd532009c482767ba9b4f0cbd9bbab65a787ac59d908d78bcf8eba6f9fcf1dd"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.9.0-dev.952+0c091feb5.tar.xz",
+        "version": "0.9.0-dev.952+0c091feb5",
+        "sha256": "e0e60edde9077e5ca0a08d58c6db4cb04f2ce069e43c6a562bf398eb6ff12f96"
+      }
+    },
+    "2021-09-14": {
+      "x86_64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.1049+5d14590ed.tar.xz",
+        "version": "0.9.0-dev.1049+5d14590ed",
+        "sha256": "9eec473fa27602317fea549408a7af5f988dae614ff1d5864603d3d7b469146f"
+      },
+      "aarch64-linux": {
+        "url": "https://ziglang.org/builds/zig-linux-aarch64-0.9.0-dev.1049+5d14590ed.tar.xz",
+        "version": "0.9.0-dev.1049+5d14590ed",
+        "sha256": "010b1aeaa245c94d8f9bb617edeceefe990172d3029090bc85cba7f24da80d3a"
+      },
+      "x86_64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-x86_64-0.9.0-dev.1049+5d14590ed.tar.xz",
+        "version": "0.9.0-dev.1049+5d14590ed",
+        "sha256": "48210c909b9d1f6403cc138386128342b326d38b319c918d2b749d36322cbef4"
+      },
+      "aarch64-darwin": {
+        "url": "https://ziglang.org/builds/zig-macos-aarch64-0.9.0-dev.1049+5d14590ed.tar.xz",
+        "version": "0.9.0-dev.1049+5d14590ed",
+        "sha256": "a544d8c7e09f08f09baf1a6836d6850d957cbdff72c868aba3961875bba8e947"
       }
     }
   },
@@ -2311,6 +2343,11 @@
       "url": "https://ziglang.org/download/0.7.1/zig-macos-x86_64-0.7.1.tar.xz",
       "version": "0.7.1",
       "sha256": "845cb17562978af0cf67e3993f4e33330525eaf01ead9386df9105111e3bc519"
+    },
+    "aarch64-darwin": {
+      "url": null,
+      "version": "0.7.1",
+      "sha256": null
     }
   },
   "0.7.0": {
@@ -2328,6 +2365,11 @@
       "url": "https://ziglang.org/download/0.7.0/zig-macos-x86_64-0.7.0.tar.xz",
       "version": "0.7.0",
       "sha256": "94063f9a311cbbf7a2e0a12295e09437182cf950f18cb0eb30ea9893f3677f24"
+    },
+    "aarch64-darwin": {
+      "url": "https://ziglang.org/download/0.7.0/zig-macos-aarch64-0.7.0.tar.xz",
+      "version": "0.7.0",
+      "sha256": "338238035734db74ea4f30e500a4893bf741d38305c10952d5e39fa05bdb057d"
     }
   },
   "0.6.0": {
@@ -2345,6 +2387,11 @@
       "url": "https://ziglang.org/download/0.6.0/zig-macos-x86_64-0.6.0.tar.xz",
       "version": "0.6.0",
       "sha256": "17270360e87ddc49f737e760047b2fac49f1570a824a306119b1194ac4093895"
+    },
+    "aarch64-darwin": {
+      "url": null,
+      "version": "0.6.0",
+      "sha256": null
     }
   },
   "0.5.0": {
@@ -2362,6 +2409,11 @@
       "url": "https://ziglang.org/download/0.5.0/zig-macos-x86_64-0.5.0.tar.xz",
       "version": "0.5.0",
       "sha256": "28702cc05745c7c0bd450487d5f4091bf0a1ad279b35eb9a640ce3e3a15b300d"
+    },
+    "aarch64-darwin": {
+      "url": null,
+      "version": "0.5.0",
+      "sha256": null
     }
   },
   "0.4.0": {
@@ -2379,6 +2431,11 @@
       "url": "https://ziglang.org/download/0.4.0/zig-macos-x86_64-0.4.0.tar.xz",
       "version": "0.4.0",
       "sha256": "67c932982484d017c5111e54af9f33f15e8e05c6bc5346a55e04052159c964a8"
+    },
+    "aarch64-darwin": {
+      "url": null,
+      "version": "0.4.0",
+      "sha256": null
     }
   },
   "0.3.0": {
@@ -2396,6 +2453,11 @@
       "url": "https://ziglang.org/download/0.3.0/zig-macos-x86_64-0.3.0.tar.xz",
       "version": "0.3.0",
       "sha256": "19dec1f1943ab7be26823376d466f7e456143deb34e17502778a949034dc2e7e"
+    },
+    "aarch64-darwin": {
+      "url": null,
+      "version": "0.3.0",
+      "sha256": null
     }
   },
   "0.2.0": {
@@ -2410,6 +2472,11 @@
       "sha256": null
     },
     "x86_64-darwin": {
+      "url": null,
+      "version": "0.2.0",
+      "sha256": null
+    },
+    "aarch64-darwin": {
       "url": null,
       "version": "0.2.0",
       "sha256": null
@@ -2430,6 +2497,11 @@
       "url": null,
       "version": "0.1.1",
       "sha256": null
+    },
+    "aarch64-darwin": {
+      "url": null,
+      "version": "0.1.1",
+      "sha256": null
     }
   },
   "0.8.0": {
@@ -2447,6 +2519,11 @@
       "url": "https://ziglang.org/download/0.8.0/zig-macos-x86_64-0.8.0.tar.xz",
       "version": "0.8.0",
       "sha256": "279f9360b5cb23103f0395dc4d3d0d30626e699b1b4be55e98fd985b62bc6fbe"
+    },
+    "aarch64-darwin": {
+      "url": "https://ziglang.org/download/0.8.0/zig-macos-aarch64-0.8.0.tar.xz",
+      "version": "0.8.0",
+      "sha256": "b32d13f66d0e1ff740b3326d66a469ee6baddbd7211fa111c066d3bd57683111"
     }
   },
   "0.8.1": {
@@ -2464,6 +2541,11 @@
       "url": "https://ziglang.org/download/0.8.1/zig-macos-x86_64-0.8.1.tar.xz",
       "version": "0.8.1",
       "sha256": "16b0e1defe4c1807f2e128f72863124bffdd906cefb21043c34b673bf85cd57f"
+    },
+    "aarch64-darwin": {
+      "url": "https://ziglang.org/download/0.8.1/zig-macos-aarch64-0.8.1.tar.xz",
+      "version": "0.8.1",
+      "sha256": "5351297e3b8408213514b29c0a938002c5cf9f97eee28c2f32920e1227fd8423"
     }
   }
 }

--- a/update
+++ b/update
@@ -7,7 +7,7 @@ require 'pathname'
 require 'fileutils'
 
 ZIG_URI = URI("https://ziglang.org/download/index.json")
-DEFAULT_SYSTEMS = ["x86_64-linux", "aarch64-linux", "x86_64-darwin"]
+DEFAULT_SYSTEMS = ["x86_64-linux", "aarch64-linux", "x86_64-darwin", "aarch64-darwin"]
 
 response = JSON.parse(Net::HTTP.get(ZIG_URI))
 sources = if Pathname.new("sources.json").exist?
@@ -22,6 +22,8 @@ response.each do |k, v|
     sources[k] = DEFAULT_SYSTEMS.to_h do |system|
       data = if system == "x86_64-darwin"
                response[k]["x86_64-macos"] or {}
+             elsif system == "aarch64-darwin"
+               response[k]["aarch64-macos"] or {}
              else
                response[k][system] or {}
              end
@@ -36,6 +38,8 @@ end
 sources["master"][response["master"]["date"]] = DEFAULT_SYSTEMS.to_h do |system|
   data = if system == "x86_64-darwin"
            response["master"]["x86_64-macos"]
+         elsif system == "aarch64-darwin"
+           response["master"]["aarch64-macos"]
          else
            response["master"][system]
          end


### PR DESCRIPTION
**Note: the `flake.lock` has been updated to include a nixpkgs version with support for aarch64-darwin.**

Since Zig now ships aarch64-macos native compilers for master and all released Zig versions, and nixpkgs unstable now supports aarch64-darwin, this PR enables pulling information on aarch64-macos builds from the Zig website.

Have tested as working on an M1 Mac w/ Nix unstable installed. 